### PR TITLE
Fixup setuptools metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def get_package_data(name, extlist):
 # Requirements
 REQUIREMENTS = ['memory_profiler']
 EXTLIST = ['.jpg', '.png', '.json', '.mo', '.ini']
-LIBNAME = 'spyder.memory_profiler'
+LIBNAME = 'spyder_memory_profiler'
 
 
 setup(
@@ -52,7 +52,7 @@ setup(
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
     keywords=["Qt PyQt4 PyQt5 PySide spyder plugins spyplugins profiler"],
     install_requires=REQUIREMENTS,
-    url='https://github.com/spyder-ide/spyder.memory_profiler',
+    url='https://github.com/spyder-ide/spyder-memory-profiler',
     license='MIT',
     author='',
     author_email='',


### PR DESCRIPTION
Following my comment in [spyder-unittest](https://github.com/spyder-ide/spyder-unittest/issues/56#issuecomment-277698506) about plugins naming consistency.

- Fixup LIBNAME to use an all underscore naming
- Fixup the project's URL