### PR TITLE
Use sys.getsizeof() to get expected memory consumption in tests

### DIFF
--- a/spyder_memory_profiler/widgets/tests/test_memoryprofiler.py
+++ b/spyder_memory_profiler/widgets/tests/test_memoryprofiler.py
@@ -7,6 +7,8 @@
 # -----------------------------------------------------------------------------
 """Tests for memoryprofiler.py."""
 
+from __future__ import division
+
 # Standard library imports
 import os
 import sys
@@ -69,19 +71,19 @@ def test_profile_and_display_results(qtbot, tmpdir, monkeypatch):
         assert top.child(i).data(0, Qt.DisplayRole) == i + 1  # line no
 
     # Column 2 has increment (in MiB); displayed as 'xxx MiB' so need to strip
-    # last 4 characters. Allow for 2% margin in measured memory consumption.
+    # last 4 characters. Allow for 5% margin in measured memory consumption.
     measured = float(top.child(2).data(2, Qt.DisplayRole)[:-4])
     list_size_in_mib = sys.getsizeof([1] * 10 ** 6) / 2 ** 20
-    assert measured >= 0.98 * list_size_in_mib
-    assert measured <= 1.02 * list_size_in_mib
+    assert measured >= 0.95 * list_size_in_mib
+    assert measured <= 1.05 * list_size_in_mib
 
     measured = float(top.child(3).data(2, Qt.DisplayRole)[:-4])
     list_size_in_mib = sys.getsizeof([2] * 2 * 10 ** 7) / 2 ** 20
-    assert measured >= 0.98 * list_size_in_mib
-    assert measured <= 1.02 * list_size_in_mib
+    assert measured >= 0.95 * list_size_in_mib
+    assert measured <= 1.05 * list_size_in_mib
 
     measured = float(top.child(4).data(2, Qt.DisplayRole)[:-4])
-    assert measured >= -1.02 * list_size_in_mib
-    assert measured <= -0.98 * list_size_in_mib
+    assert measured >= -1.05 * list_size_in_mib
+    assert measured <= -0.95 * list_size_in_mib
 
     assert float(top.child(5).data(2, Qt.DisplayRole)[:-4]) == 0


### PR DESCRIPTION
This takes care of size differences in cpython on 32-bit versus 64-bit machines. Fixes #14.