### PR TITLE
Make test more robust

### DIFF
--- a/spyder_memory_profiler/widgets/tests/test_memoryprofiler.py
+++ b/spyder_memory_profiler/widgets/tests/test_memoryprofiler.py
@@ -72,19 +72,8 @@ def test_profile_and_display_results(qtbot, tmpdir, monkeypatch):
         assert top.child(i).data(0, Qt.DisplayRole) == i + 1  # line no
 
     # Column 2 has increment (in MiB); displayed as 'xxx MiB' so need to strip
-    # last 4 characters. Allow for 5% margin in measured memory consumption.
-    measured = float(top.child(2).data(2, Qt.DisplayRole)[:-4])
-    list_size_in_mib = sys.getsizeof([1] * 10 ** 6) / 2 ** 20
-    assert measured >= 0.95 * list_size_in_mib
-    assert measured <= 1.05 * list_size_in_mib
-
-    measured = float(top.child(3).data(2, Qt.DisplayRole)[:-4])
-    list_size_in_mib = sys.getsizeof([2] * 2 * 10 ** 7) / 2 ** 20
-    assert measured >= 0.95 * list_size_in_mib
-    assert measured <= 1.05 * list_size_in_mib
-
-    measured = float(top.child(4).data(2, Qt.DisplayRole)[:-4])
-    assert measured >= -1.05 * list_size_in_mib
-    assert measured <= -0.95 * list_size_in_mib
-
+    # last 4 characters. To make the test robust, we only check the sign
+    assert float(top.child(2).data(2, Qt.DisplayRole)[:-4]) > 0
+    assert float(top.child(3).data(2, Qt.DisplayRole)[:-4]) > 0
+    assert float(top.child(4).data(2, Qt.DisplayRole)[:-4]) < 0
     assert float(top.child(5).data(2, Qt.DisplayRole)[:-4]) == 0


### PR DESCRIPTION
Make test more robust by only checking sign of measured memory consumption. The previous test failed on some 32-bits computers, even with 5% margin; see comments at 4da36a2.