### PR TITLE
Restrict recursive inclusion filter

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include CHANGELOG.md LICENSE.txt README.rst
-recursive-include spyder_memory_profiler *
+recursive-include spyder_memory_profiler *.py *.png


### PR DESCRIPTION
Otherwise, the upstream tarball may contain cache files (such as in the current tarball for version `0.1.1`). A manual inspection of the tarball before upload would have prevented that mistake.